### PR TITLE
Issue #GEN-238: Added service override to hide drupal_set_message

### DIFF
--- a/web/modules/custom/genlyd_maps/src/Controller/ApiController.php
+++ b/web/modules/custom/genlyd_maps/src/Controller/ApiController.php
@@ -139,15 +139,7 @@ class ApiController extends ControllerBase {
       ], ',');
 
       // Returns false if address does not exist.
-      try {
-        $addressCollection = $geocoder->geocode($address, $plugins, $options);
-      }
-      catch (InvalidCredentials $e) {
-        // Ignore error.
-      }
-      catch (NoResult $e) {
-        // Ignore error.
-      }
+      $addressCollection = $geocoder->geocode($address, $plugins, $options);
 
       if ($addressCollection) {
         $latitude = $addressCollection->first()->getCoordinates()->getLatitude();

--- a/web/modules/custom/genlyd_maps/src/GenlydMapsServiceProvider.php
+++ b/web/modules/custom/genlyd_maps/src/GenlydMapsServiceProvider.php
@@ -17,12 +17,11 @@ class GenlydMapsServiceProvider extends ServiceProviderBase {
 
   /**
    * {@inheritdoc}
-   *
-   * @TODO: Remove this when the geocoding is handled in activity create.
    */
   public function alter(ContainerBuilder $container) {
     // Override geocoder service.
     $definition = $container->getDefinition('geocoder');
     $definition->setClass(Geocoder::class);
   }
+
 }

--- a/web/modules/custom/genlyd_maps/src/GenlydMapsServiceProvider.php
+++ b/web/modules/custom/genlyd_maps/src/GenlydMapsServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @file
+ * Contains service overrides.
+ */
+
+namespace Drupal\genlyd_maps;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Drupal\genlyd_maps\Service\Geocoder;
+
+/**
+ * Modifies the language manager service.
+ */
+class GenlydMapsServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   *
+   * @TODO: Remove this when the geocoding is handled in activity create.
+   */
+  public function alter(ContainerBuilder $container) {
+    // Override geocoder service.
+    $definition = $container->getDefinition('geocoder');
+    $definition->setClass(Geocoder::class);
+  }
+}

--- a/web/modules/custom/genlyd_maps/src/Service/Geocoder.php
+++ b/web/modules/custom/genlyd_maps/src/Service/Geocoder.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * Contains override of geocoder service.
+ */
+
+namespace Drupal\genlyd_maps\Service;
+
+class Geocoder extends \Drupal\geocoder\Geocoder {
+
+  /**
+   * Overrides Geocoder log function to avoid the drupal_set_message.
+   *
+   * Log a message in the Drupal watchdog.
+   *
+   * @param string $message
+   *   The message.
+   * @param string $type
+   *   The type of message.
+   */
+  public static function log($message, $type) {
+    \Drupal::logger('geocoder')->log($type, $message);
+  }
+
+}


### PR DESCRIPTION
This is a temporary solution. 
The correct solution is to make this call (and thereby validate the address) when creating/editing an activity. This would also make the map faster.